### PR TITLE
Browser variant

### DIFF
--- a/10.22/browsers/Dockerfile
+++ b/10.22/browsers/Dockerfile
@@ -1,0 +1,45 @@
+# vim:set ft=dockerfile:
+
+# This file is a duplicate of:
+# https://github.com/CircleCI-Public/cimg-shared/blob/master/variants/browsers.Dockerfile.template
+# The reason this exists is that the Node.js image needed its own version of
+# the browsers variant. The normal version is based on the node variant of that
+# image. As this IS a Node image, there isn't a node variant.
+
+FROM cimg/node:10.22.1
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+    # Google Chrome deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+        # java for selenium
+        openjdk-11-jre \
+        xdg-utils \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*

--- a/12.18/browsers/Dockerfile
+++ b/12.18/browsers/Dockerfile
@@ -1,0 +1,45 @@
+# vim:set ft=dockerfile:
+
+# This file is a duplicate of:
+# https://github.com/CircleCI-Public/cimg-shared/blob/master/variants/browsers.Dockerfile.template
+# The reason this exists is that the Node.js image needed its own version of
+# the browsers variant. The normal version is based on the node variant of that
+# image. As this IS a Node image, there isn't a node variant.
+
+FROM cimg/node:12.18.4
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+    # Google Chrome deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+        # java for selenium
+        openjdk-11-jre \
+        xdg-utils \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*

--- a/12.19/browsers/Dockerfile
+++ b/12.19/browsers/Dockerfile
@@ -1,0 +1,45 @@
+# vim:set ft=dockerfile:
+
+# This file is a duplicate of:
+# https://github.com/CircleCI-Public/cimg-shared/blob/master/variants/browsers.Dockerfile.template
+# The reason this exists is that the Node.js image needed its own version of
+# the browsers variant. The normal version is based on the node variant of that
+# image. As this IS a Node image, there isn't a node variant.
+
+FROM cimg/node:12.19.0
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+    # Google Chrome deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+        # java for selenium
+        openjdk-11-jre \
+        xdg-utils \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*

--- a/14.12/browsers/Dockerfile
+++ b/14.12/browsers/Dockerfile
@@ -1,0 +1,45 @@
+# vim:set ft=dockerfile:
+
+# This file is a duplicate of:
+# https://github.com/CircleCI-Public/cimg-shared/blob/master/variants/browsers.Dockerfile.template
+# The reason this exists is that the Node.js image needed its own version of
+# the browsers variant. The normal version is based on the node variant of that
+# image. As this IS a Node image, there isn't a node variant.
+
+FROM cimg/node:14.12.0
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+    # Google Chrome deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+        # java for selenium
+        openjdk-11-jre \
+        xdg-utils \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*

--- a/14.13/browsers/Dockerfile
+++ b/14.13/browsers/Dockerfile
@@ -1,0 +1,45 @@
+# vim:set ft=dockerfile:
+
+# This file is a duplicate of:
+# https://github.com/CircleCI-Public/cimg-shared/blob/master/variants/browsers.Dockerfile.template
+# The reason this exists is that the Node.js image needed its own version of
+# the browsers variant. The normal version is based on the node variant of that
+# image. As this IS a Node image, there isn't a node variant.
+
+FROM cimg/node:14.13.1
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+    # Google Chrome deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+        # java for selenium
+        openjdk-11-jre \
+        xdg-utils \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-docker build --file 14.13/Dockerfile -t cimg/node:14.13.1  -t cimg/node:14.13  -t cimg/node:current .
+docker build --file 10.22/browsers/Dockerfile -t cimg/node:10.22.1-browsers  -t cimg/node:10.22-browsers .
+docker build --file 12.18/browsers/Dockerfile -t cimg/node:12.18.4-browsers  -t cimg/node:12.18-browsers .
+docker build --file 12.19/browsers/Dockerfile -t cimg/node:12.19.0-browsers  -t cimg/node:12.19-browsers .
+docker build --file 14.12/browsers/Dockerfile -t cimg/node:14.12.0-browsers  -t cimg/node:14.12-browsers .
+docker build --file 14.13/browsers/Dockerfile -t cimg/node:14.13.1-browsers  -t cimg/node:14.13-browsers .

--- a/manifest
+++ b/manifest
@@ -2,4 +2,4 @@
 
 repository=node
 parent=base
-variants=()
+variants=(browsers)

--- a/variants/browsers.Dockerfile.template
+++ b/variants/browsers.Dockerfile.template
@@ -1,0 +1,45 @@
+# vim:set ft=dockerfile:
+
+# This file is a duplicate of:
+# https://github.com/CircleCI-Public/cimg-shared/blob/master/variants/browsers.Dockerfile.template
+# The reason this exists is that the Node.js image needed its own version of
+# the browsers variant. The normal version is based on the node variant of that
+# image. As this IS a Node image, there isn't a node variant.
+
+FROM cimg/%%PARENT%%:%%PARENT_TAG%%
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+    # Google Chrome deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+        # java for selenium
+        openjdk-11-jre \
+        xdg-utils \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Enable a browsers variant for Node v10.22.1, v12.18.4, v12.19.0, v14.12.0, and v14.13.1. Readme not updated yet as this is a beta.