### PR TITLE
Update README.md for dev-hub parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ For example:
 jobs:
   build:
     docker:
-      - image: cimg/node:12.16
+      - image: cimg/node:15.0.1
     steps:
       - checkout
       - run: node --version
 ```
 
 In the above example, the CircleCI Node.js Docker image is used for the primary container.
-More specifically, the tag `12.16` is used meaning the version of Node.js will be Node.js v12.16.
+More specifically, the tag `15.0.1` is used meaning the version of Node.js will be Node.js v15.0.1.
 You can now use Node.js within the steps for this job.
 
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
 ```
 
 In the above example, the CircleCI Node.js Docker image is used for the primary container.
-More specifically, the tag `12.16` is used meaning the version of Node.js will be Node.js v12.16.x where 'x' is the latest patch release.
+More specifically, the tag `12.16` is used meaning the version of Node.js will be Node.js v12.16.
 You can now use Node.js within the steps for this job.
 
 


### PR DESCRIPTION
In the dev-hub we are going to automatically sync the content from the cimg READMEs.
As a part of the copy in the dev-hub, the semantic versions in the Getting Started header are going to be updated to the latest tag.

https://circleci.com/developer/images/image/cimg/node
Currently, the sample config is updated with the latest version semver, but the description below it mentions the text here.
As we automatically sync the content, we're simply going to update the semver in the entire header. This change makes the content in the header make more sense.
The explanation of the semver tags is in the `Tagging Scheme` header.