### PR TITLE
Add docker images for node 12.15.0

### DIFF
--- a/12.15/Dockerfile
+++ b/12.15/Dockerfile
@@ -1,0 +1,20 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/base:2021.07
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV NODE_VERSION 12.15.0
+
+RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV PATH /home/circleci/.yarn/bin:$PATH
+ENV YARN_VERSION 1.22.11
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/12.15/browsers/Dockerfile
+++ b/12.15/browsers/Dockerfile
@@ -1,0 +1,68 @@
+# vim:set ft=dockerfile:
+
+# This file is a duplicate of:
+# https://github.com/CircleCI-Public/cimg-shared/blob/master/variants/browsers.Dockerfile.template
+# The reason this exists is that the Node.js image needed its own version of
+# the browsers variant. The normal version is based on the node variant of that
+# image. As this IS a Node image, there isn't a node variant.
+
+FROM cimg/node:12.15.0
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+    # Google Chrome deps
+	# Some of these packages should be pulled into their own section
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+		libxss1 \
+        xdg-utils \
+		xvfb \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]


### PR DESCRIPTION
We just migrated from the legacy circleci/node images to the new cimg/node and our project currently uses node v 12.15.0 so I thought it would be easier if this convenience image was available directly without having to build it myself and store it in our own ecr