### PR TITLE
Upgrade Docker build system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,11 @@ workflows:
 jobs:
   build:
     docker:
-      - image: cibuilds/docker:19.03
+      - image: cimg/base:2021.10
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.11
       - run:
           name: "Build Docker Images"
           command: |
@@ -29,6 +30,7 @@ jobs:
               if git log -1 --pretty=%s | grep "\[release\]"; then
                 echo "Publishing cimg/node to Docker Hub production."
                 docker push cimg/node
+                ./push-images.sh
               else
                 echo "Skipping publishing."
               fi

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash


### PR DESCRIPTION
This switches to the base image for the build image. This means:

- jumping from an Alpine base to an Ubuntu base
- using our base image which is always good
- using a newer release of Git
- using a newer release of Docker

These things allow us to use the new `push-images.sh` script as well as
use newer features of git that we need for a separate PR.