### PR TITLE
Fix two build issues from PR #195

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
               # an else block will be added in the future for a staging release
               if git log -1 --pretty=%s | grep "\[release\]"; then
                 echo "Publishing cimg/node to Docker Hub production."
-                docker push cimg/node
                 ./push-images.sh
               else
                 echo "Skipping publishing."
@@ -38,7 +37,7 @@ jobs:
               # Update the Docker Hub description
               STUBB_VER=0.2.0
               STUBB_URL="https://github.com/CircleCI-Public/stubb/releases/download/v${STUBB_VER}/stubb_${STUBB_VER}-linux-amd64.tar.gz"
-              curl -sSL $STUBB_URL | tar -xz -C /usr/local/bin stubb
+              curl -sSL $STUBB_URL | tar -xz -C $HOME/bin stubb
 
               stubb set description cimg/node ./README.md
             fi


### PR DESCRIPTION
1. The docker push command isn't used/needed anymore and
2. there's a permission error now for stubb based on the file path.