### PR TITLE
Fix invalid command path on non-interactive env

### DIFF
--- a/18.1/Dockerfile
+++ b/18.1/Dockerfile
@@ -8,6 +8,7 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 
 ENV NODE_VERSION 18.1.0
 ENV NVM_DIR /home/circleci/.nvm
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:/home/circleci/.yarn/bin:$PATH
 
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
 	echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.bashrc && \


### PR DESCRIPTION
`18.1/Dockerfile` doesn't contain `ENV PATH ...` like previous versions. So some commands like `node`, `npm` etc are not found on non-interactive environments.

I fixed this.

### Example
- For example [CircleCI job](https://app.circleci.com/pipelines/github/nikukyugamer/hiuihhihi/191/workflows/90a7c48b-0892-4a15-9579-d283fe4b7ea0/jobs/187
) 
  - It's my job.
  - `Node.js` isn't found.
  - `.circleci/config.yml` diff is here.
    - https://github.com/nikukyugamer/hiuihhihi/pull/86/files

### Checking the fix easily
To check the fix easily, execute `$ docker container run --rm IMAGE_FILE:TAG node -v`

#### 1. Docker Image on not-modified Dockerfile

```bash
$ docker container run --rm not_modified_cimg_node_18_1 node -v
docker: Error response from daemon: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "node": executable file not found in $PATH: unknown.
```

#### 2. Docker Image on modified Dockerfile

```bash
# On modified Dockerfile
$ docker container run --rm modified_cimg_node_18_1 node -v
v18.1.0
```
