### PR TITLE
Respin recent image tags for nvm fix [release]

### DIFF
--- a/12.13/Dockerfile
+++ b/12.13/Dockerfile
@@ -6,16 +6,21 @@ FROM cimg/base:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV NODE_VERSION 12.13.1
+ENV NODE_VER 12.13.1
 ENV NVM_DIR /home/circleci/.nvm
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:/home/circleci/.yarn/bin:$PATH
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
-	echo '\. "$NVM_DIR/nvm.sh" --no-use' >> ~/.bashrc
+# Next two lines should be moved to cimg/base
+ENV BASH_ENV /home/circleci/.circlerc
+RUN touch /home/circleci/.circlerc && \
+	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
+	echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.circlerc && \
+	source ~/.circlerc && nvm install $NODE_VER && \
+	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
+	command -v nvm
 
-ENV YARN_VERSION 1.22.18
-RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+ENV YARN_VER 1.22.18
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
+	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/14.19/Dockerfile
+++ b/14.19/Dockerfile
@@ -6,16 +6,21 @@ FROM cimg/base:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV NODE_VERSION 14.19.2
+ENV NODE_VER 14.19.2
 ENV NVM_DIR /home/circleci/.nvm
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:/home/circleci/.yarn/bin:$PATH
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
-	echo '\. "$NVM_DIR/nvm.sh" --no-use' >> ~/.bashrc
+# Next two lines should be moved to cimg/base
+ENV BASH_ENV /home/circleci/.circlerc
+RUN touch /home/circleci/.circlerc && \
+	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
+	echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.circlerc && \
+	source ~/.circlerc && nvm install $NODE_VER && \
+	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
+	command -v nvm
 
-ENV YARN_VERSION 1.22.18
-RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+ENV YARN_VER 1.22.18
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
+	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/16.15/Dockerfile
+++ b/16.15/Dockerfile
@@ -6,16 +6,21 @@ FROM cimg/base:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV NODE_VERSION 16.15.0
+ENV NODE_VER 16.15.0
 ENV NVM_DIR /home/circleci/.nvm
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:/home/circleci/.yarn/bin:$PATH
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
-	echo '\. "$NVM_DIR/nvm.sh" --no-use' >> ~/.bashrc
+# Next two lines should be moved to cimg/base
+ENV BASH_ENV /home/circleci/.circlerc
+RUN touch /home/circleci/.circlerc && \
+	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
+	echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.circlerc && \
+	source ~/.circlerc && nvm install $NODE_VER && \
+	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
+	command -v nvm
 
-ENV YARN_VERSION 1.22.18
-RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+ENV YARN_VER 1.22.18
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
+	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/18.1/Dockerfile
+++ b/18.1/Dockerfile
@@ -6,16 +6,21 @@ FROM cimg/base:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV NODE_VERSION 18.1.0
+ENV NODE_VER 18.1.0
 ENV NVM_DIR /home/circleci/.nvm
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:/home/circleci/.yarn/bin:$PATH
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
-	echo '\. "$NVM_DIR/nvm.sh" --no-use' >> ~/.bashrc
+# Next two lines should be moved to cimg/base
+ENV BASH_ENV /home/circleci/.circlerc
+RUN touch /home/circleci/.circlerc && \
+	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
+	echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.circlerc && \
+	source ~/.circlerc && nvm install $NODE_VER && \
+	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
+	command -v nvm
 
-ENV YARN_VERSION 1.22.18
-RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+ENV YARN_VER 1.22.18
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
+	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,16 +6,21 @@ FROM cimg/%%PARENT%%:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV NODE_VERSION %%VERSION_FULL%%
+ENV NODE_VER %%VERSION_FULL%%
 ENV NVM_DIR /home/circleci/.nvm
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:/home/circleci/.yarn/bin:$PATH
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
-	echo '\. "$NVM_DIR/nvm.sh" --no-use' >> ~/.bashrc
+# Next two lines should be moved to cimg/base
+ENV BASH_ENV /home/circleci/.circlerc
+RUN touch /home/circleci/.circlerc && \
+	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
+	echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.circlerc && \
+	source ~/.circlerc && nvm install $NODE_VER && \
+	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
+	command -v nvm
 
-ENV YARN_VERSION 1.22.18
-RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+ENV YARN_VER 1.22.18
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
+	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
+docker build --file 12.13/Dockerfile -t cimg/node:12.13.1  -t cimg/node:12.13 .
+docker build --file 12.13/browsers/Dockerfile -t cimg/node:12.13.1-browsers  -t cimg/node:12.13-browsers .
+docker build --file 14.19/Dockerfile -t cimg/node:14.19.2  -t cimg/node:14.19 .
+docker build --file 14.19/browsers/Dockerfile -t cimg/node:14.19.2-browsers  -t cimg/node:14.19-browsers .
 docker build --file 16.15/Dockerfile -t cimg/node:16.15.0  -t cimg/node:16.15  -t cimg/node:lts .
 docker build --file 16.15/browsers/Dockerfile -t cimg/node:16.15.0-browsers  -t cimg/node:16.15-browsers  -t cimg/node:lts-browsers .
 docker build --file 18.1/Dockerfile -t cimg/node:18.1.0  -t cimg/node:18.1  -t cimg/node:current .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
+docker push cimg/node:12.13.1
+docker push cimg/node:12.13
+docker push cimg/node:12.13.1-browsers
+docker push cimg/node:12.13-browsers
+
+docker push cimg/node:14.19.2
+docker push cimg/node:14.19
+docker push cimg/node:14.19.2-browsers
+docker push cimg/node:14.19-browsers
+
 docker push cimg/node:16.15.0
 docker push cimg/node:16.15
 docker push cimg/node:lts


### PR DESCRIPTION
Fixes #241 

This PR fixes the installation of nvm. Now:

- the default (pre-installed) version of Node.js is available
- npm global modules can be installed as global without `sudo`
- additional node versions can be installed successfully