### PR TITLE
fix: _VER variables break yarn

### DIFF
--- a/12.13/Dockerfile
+++ b/12.13/Dockerfile
@@ -19,8 +19,8 @@ RUN touch /home/circleci/.circlerc && \
 	command -v nvm
 
 ENV YARN_VERSION 1.22.18
-RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
-	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarnpkg /usr/local/bin/yarnpkg
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/12.13/Dockerfile
+++ b/12.13/Dockerfile
@@ -6,7 +6,7 @@ FROM cimg/base:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV NODE_VER 12.13.1
+ENV NODE_VERSION 12.13.1
 ENV NVM_DIR /home/circleci/.nvm
 
 # Next two lines should be moved to cimg/base
@@ -14,11 +14,11 @@ ENV BASH_ENV /home/circleci/.circlerc
 RUN touch /home/circleci/.circlerc && \
 	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
 	echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.circlerc && \
-	source ~/.circlerc && nvm install $NODE_VER && \
+	source ~/.circlerc && nvm install $NODE_VERSION && \
 	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
 	command -v nvm
 
-ENV YARN_VER 1.22.18
+ENV YARN_VERSION 1.22.18
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/14.19/Dockerfile
+++ b/14.19/Dockerfile
@@ -6,7 +6,7 @@ FROM cimg/base:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV NODE_VER 14.19.2
+ENV NODE_VERSION 14.19.2
 ENV NVM_DIR /home/circleci/.nvm
 
 # Next two lines should be moved to cimg/base
@@ -14,11 +14,11 @@ ENV BASH_ENV /home/circleci/.circlerc
 RUN touch /home/circleci/.circlerc && \
 	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
 	echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.circlerc && \
-	source ~/.circlerc && nvm install $NODE_VER && \
+	source ~/.circlerc && nvm install $NODE_VERSION && \
 	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
 	command -v nvm
 
-ENV YARN_VER 1.22.18
+ENV YARN_VERSION 1.22.18
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/14.19/Dockerfile
+++ b/14.19/Dockerfile
@@ -19,8 +19,8 @@ RUN touch /home/circleci/.circlerc && \
 	command -v nvm
 
 ENV YARN_VERSION 1.22.18
-RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
-	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarnpkg /usr/local/bin/yarnpkg
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/16.15/Dockerfile
+++ b/16.15/Dockerfile
@@ -6,7 +6,7 @@ FROM cimg/base:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV NODE_VER 16.15.0
+ENV NODE_VERSION 16.15.0
 ENV NVM_DIR /home/circleci/.nvm
 
 # Next two lines should be moved to cimg/base
@@ -18,7 +18,7 @@ RUN touch /home/circleci/.circlerc && \
 	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
 	command -v nvm
 
-ENV YARN_VER 1.22.18
+ENV YARN_VERSION 1.22.18
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/16.15/Dockerfile
+++ b/16.15/Dockerfile
@@ -19,8 +19,8 @@ RUN touch /home/circleci/.circlerc && \
 	command -v nvm
 
 ENV YARN_VERSION 1.22.18
-RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
-	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarnpkg /usr/local/bin/yarnpkg
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/16.15/Dockerfile
+++ b/16.15/Dockerfile
@@ -14,7 +14,7 @@ ENV BASH_ENV /home/circleci/.circlerc
 RUN touch /home/circleci/.circlerc && \
 	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
 	echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.circlerc && \
-	source ~/.circlerc && nvm install $NODE_VER && \
+	source ~/.circlerc && nvm install $NODE_VERSION && \
 	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
 	command -v nvm
 

--- a/18.1/Dockerfile
+++ b/18.1/Dockerfile
@@ -19,8 +19,8 @@ RUN touch /home/circleci/.circlerc && \
 	command -v nvm
 
 ENV YARN_VERSION 1.22.18
-RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
-	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarnpkg /usr/local/bin/yarnpkg
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/18.1/Dockerfile
+++ b/18.1/Dockerfile
@@ -6,7 +6,7 @@ FROM cimg/base:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV NODE_VER 18.1.0
+ENV NODE_VERSION 18.1.0
 ENV NVM_DIR /home/circleci/.nvm
 
 # Next two lines should be moved to cimg/base
@@ -14,11 +14,11 @@ ENV BASH_ENV /home/circleci/.circlerc
 RUN touch /home/circleci/.circlerc && \
 	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
 	echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.circlerc && \
-	source ~/.circlerc && nvm install $NODE_VER && \
+	source ~/.circlerc && nvm install $NODE_VERSION && \
 	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
 	command -v nvm
 
-ENV YARN_VER 1.22.18
+ENV YARN_VERSION 1.22.18
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,7 @@ FROM cimg/%%PARENT%%:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV NODE_VER %%VERSION_FULL%%
+ENV NODE_VERSION %%VERSION_FULL%%
 ENV NVM_DIR /home/circleci/.nvm
 
 # Next two lines should be moved to cimg/base
@@ -14,13 +14,13 @@ ENV BASH_ENV /home/circleci/.circlerc
 RUN touch /home/circleci/.circlerc && \
 	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
 	echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.circlerc && \
-	source ~/.circlerc && nvm install $NODE_VER && \
+	source ~/.circlerc && nvm install $NODE_VERSION && \
 	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
 	command -v nvm
 
-ENV YARN_VER 1.22.18
-RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VER}/yarn-v${YARN_VER}.tar.gz" && \
+ENV YARN_VERSION 1.22.18
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
-	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VER}/bin/yarnpkg /usr/local/bin/yarnpkg
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 12.13/Dockerfile -t cimg/node:12.13.1  -t cimg/node:12.13 .
-docker build --file 12.13/browsers/Dockerfile -t cimg/node:12.13.1-browsers  -t cimg/node:12.13-browsers .
-docker build --file 14.19/Dockerfile -t cimg/node:14.19.2  -t cimg/node:14.19 .
-docker build --file 14.19/browsers/Dockerfile -t cimg/node:14.19.2-browsers  -t cimg/node:14.19-browsers .
-docker build --file 16.15/Dockerfile -t cimg/node:16.15.0  -t cimg/node:16.15  -t cimg/node:lts .
-docker build --file 16.15/browsers/Dockerfile -t cimg/node:16.15.0-browsers  -t cimg/node:16.15-browsers  -t cimg/node:lts-browsers .
-docker build --file 18.1/Dockerfile -t cimg/node:18.1.0  -t cimg/node:18.1  -t cimg/node:current .
-docker build --file 18.1/browsers/Dockerfile -t cimg/node:18.1.0-browsers  -t cimg/node:18.1-browsers  -t cimg/node:current-browsers .
+docker build --file 12.13/Dockerfile -t cimg/node:12.13.1 -t cimg/node:12.13 .
+docker build --file 12.13/browsers/Dockerfile -t cimg/node:12.13.1-browsers -t cimg/node:12.13-browsers .
+docker build --file 14.19/Dockerfile -t cimg/node:14.19.2 -t cimg/node:14.19 .
+docker build --file 14.19/browsers/Dockerfile -t cimg/node:14.19.2-browsers -t cimg/node:14.19-browsers .
+docker build --file 16.15/Dockerfile -t cimg/node:16.15.0 -t cimg/node:16.15 .
+docker build --file 16.15/browsers/Dockerfile -t cimg/node:16.15.0-browsers -t cimg/node:16.15-browsers .
+docker build --file 18.1/Dockerfile -t cimg/node:18.1.0 -t cimg/node:18.1 .
+docker build --file 18.1/browsers/Dockerfile -t cimg/node:18.1.0-browsers -t cimg/node:18.1-browsers .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,26 +1,18 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
-
-docker push cimg/node:12.13.1
 docker push cimg/node:12.13
-docker push cimg/node:12.13.1-browsers
+docker push cimg/node:12.13.1
 docker push cimg/node:12.13-browsers
-
-docker push cimg/node:14.19.2
+docker push cimg/node:12.13.1-browsers
 docker push cimg/node:14.19
-docker push cimg/node:14.19.2-browsers
+docker push cimg/node:14.19.2
 docker push cimg/node:14.19-browsers
-
-docker push cimg/node:16.15.0
+docker push cimg/node:14.19.2-browsers
 docker push cimg/node:16.15
-docker push cimg/node:lts
-docker push cimg/node:16.15.0-browsers
+docker push cimg/node:16.15.0
 docker push cimg/node:16.15-browsers
-docker push cimg/node:lts-browsers
-
-docker push cimg/node:18.1.0
+docker push cimg/node:16.15.0-browsers
 docker push cimg/node:18.1
-docker push cimg/node:current
-docker push cimg/node:18.1.0-browsers
+docker push cimg/node:18.1.0
 docker push cimg/node:18.1-browsers
-docker push cimg/node:current-browsers
+docker push cimg/node:18.1.0-browsers


### PR DESCRIPTION
The new `cimg/node:lts`, which points at 16.15, breaks `yarn` berry:

```
 docker run -it --rm --entrypoint bash cimg/node:lts
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
circleci@9fdbb66acc23:~/project$ yarn set version berry
Usage Error: Unrecognized or legacy configuration settings found: ver - run "yarn config -v" to see the list of settings supported in Yarn (in <environment>)

$ yarn set version [--only-if-needed] <version>
circleci@9fdbb66acc23:~/project$ unset YARN_VER
circleci@9fdbb66acc23:~/project$ yarn set version berry
➤ YN0000: Retrieving https://repo.yarnpkg.com/3.2.0/packages/yarnpkg-cli/bin/yarn.js
➤ YN0000: Saving the new release in .yarn/releases/yarn-3.2.0.cjs
➤ YN0000: Done in 2s 453ms
```

In all other Dockerfiles, you're using `YARN_VERSION`, not `YARN_VER`. Since this breaks all yarn v2+ (berry) users, I think it's worth publishing over the existing image.