### PR TITLE
spin lts and current [release]

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 12.13/Dockerfile -t cimg/node:12.13.1 -t cimg/node:12.13 .
-docker build --file 12.13/browsers/Dockerfile -t cimg/node:12.13.1-browsers -t cimg/node:12.13-browsers .
-docker build --file 14.19/Dockerfile -t cimg/node:14.19.2 -t cimg/node:14.19 .
-docker build --file 14.19/browsers/Dockerfile -t cimg/node:14.19.2-browsers -t cimg/node:14.19-browsers .
-docker build --file 16.15/Dockerfile -t cimg/node:16.15.0 -t cimg/node:16.15 .
-docker build --file 16.15/browsers/Dockerfile -t cimg/node:16.15.0-browsers -t cimg/node:16.15-browsers .
-docker build --file 18.1/Dockerfile -t cimg/node:18.1.0 -t cimg/node:18.1 .
-docker build --file 18.1/browsers/Dockerfile -t cimg/node:18.1.0-browsers -t cimg/node:18.1-browsers .
+docker build --file 16.15/Dockerfile -t cimg/node:16.15.0  -t cimg/node:16.15  -t cimg/node:lts .
+docker build --file 16.15/browsers/Dockerfile -t cimg/node:16.15.0-browsers  -t cimg/node:16.15-browsers  -t cimg/node:lts-browsers .
+docker build --file 18.1/Dockerfile -t cimg/node:18.1.0  -t cimg/node:18.1  -t cimg/node:current .
+docker build --file 18.1/browsers/Dockerfile -t cimg/node:18.1.0-browsers  -t cimg/node:18.1-browsers  -t cimg/node:current-browsers .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,18 +1,16 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
-docker push cimg/node:12.13
-docker push cimg/node:12.13.1
-docker push cimg/node:12.13-browsers
-docker push cimg/node:12.13.1-browsers
-docker push cimg/node:14.19
-docker push cimg/node:14.19.2
-docker push cimg/node:14.19-browsers
-docker push cimg/node:14.19.2-browsers
-docker push cimg/node:16.15
+
 docker push cimg/node:16.15.0
-docker push cimg/node:16.15-browsers
+docker push cimg/node:16.15
+docker push cimg/node:lts
 docker push cimg/node:16.15.0-browsers
-docker push cimg/node:18.1
+docker push cimg/node:16.15-browsers
+docker push cimg/node:lts-browsers
+
 docker push cimg/node:18.1.0
-docker push cimg/node:18.1-browsers
+docker push cimg/node:18.1
+docker push cimg/node:current
 docker push cimg/node:18.1.0-browsers
+docker push cimg/node:18.1-browsers
+docker push cimg/node:current-browsers

--- a/push-images.sh
+++ b/push-images.sh
@@ -13,4 +13,4 @@ docker push cimg/node:18.1
 docker push cimg/node:current
 docker push cimg/node:18.1.0-browsers
 docker push cimg/node:18.1-browsers
-docker push cimg/node:current-browsers
+docker push cimg/node:current-browsers 


### PR DESCRIPTION
since there was a change in the shared submodule, lts and current tags weren't being created. this fixes that