### PR TITLE
Reimplement vanilla node

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -7,16 +7,13 @@ FROM cimg/%%PARENT%%:2022.06
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 ENV NODE_VERSION %%VERSION_FULL%%
-ENV NVM_DIR /home/circleci/.nvm
 
-# Next two lines should be moved to cimg/base
-ENV BASH_ENV /home/circleci/.circlerc
-RUN touch /home/circleci/.circlerc && \
-	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
-	echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.circlerc && \
-	source ~/.circlerc && nvm install $NODE_VERSION && \
-	echo -e ". /home/circleci/.circlerc\n$( cat ~/.bashrc )" > ~/.bashrc && \
-	command -v nvm
+RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV PATH /home/circleci/.yarn/bin:$PATH
 
 ENV YARN_VERSION 1.22.18
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \


### PR DESCRIPTION
Re-implementing vanilla node in order to keep things deterministic. While having the option to change versions of node on the fly, it is ultimately not needed and can be achieved through the orb. Additionally, nvm introduced a couple of undesired effects that interfered with usage.

There are other options that don't interfere with node and that may be a way to go later down the road.

Closes #265 