### PR TITLE
Publish v19.0.0. [release]

### DIFF
--- a/19.0/Dockerfile
+++ b/19.0/Dockerfile
@@ -1,0 +1,29 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+# By policy, the base image tag should be a quarterly tag unless there's a 
+# specific reason to use a different one. This means January, April, July, or 
+# October.
+FROM cimg/base:2022.10
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV NODE_VERSION 19.0.0
+
+RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV PATH /home/circleci/.yarn/bin:$PATH
+
+ENV YARN_VERSION 1.22.18
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
+
+# Install an alternative, but growing in popularity Node.js package manager
+RUN sudo npm install -g pnpm

--- a/19.0/browsers/Dockerfile
+++ b/19.0/browsers/Dockerfile
@@ -1,0 +1,68 @@
+# vim:set ft=dockerfile:
+
+# This file is a duplicate of:
+# https://github.com/CircleCI-Public/cimg-shared/blob/master/variants/browsers.Dockerfile.template
+# The reason this exists is that the Node.js image needed its own version of
+# the browsers variant. The normal version is based on the node variant of that
+# image. As this IS a Node image, there isn't a node variant.
+
+FROM cimg/node:19.0.0
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+    # Google Chrome deps
+	# Some of these packages should be pulled into their own section
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+		libxss1 \
+        xdg-utils \
+		xvfb \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/ALIASES
+++ b/ALIASES
@@ -1,2 +1,2 @@
 lts=16.18.0
-current=18.11.0
+current=19.0.0

--- a/GEN-CHECK
+++ b/GEN-CHECK
@@ -1,1 +1,1 @@
-GEN_CHECK=(16.18.0 18.11.0=current)
+GEN_CHECK=(19.0.0=current)

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 16.18/Dockerfile -t cimg/node:16.18.0 -t cimg/node:16.18 .
-docker build --file 16.18/browsers/Dockerfile -t cimg/node:16.18.0-browsers -t cimg/node:16.18-browsers .
-docker build --file 18.11/Dockerfile -t cimg/node:18.11.0 -t cimg/node:18.11 .
-docker build --file 18.11/browsers/Dockerfile -t cimg/node:18.11.0-browsers -t cimg/node:18.11-browsers .
+docker build --file 19.0/Dockerfile -t cimg/node:19.0.0 -t cimg/node:19.0 .
+docker build --file 19.0/browsers/Dockerfile -t cimg/node:19.0.0-browsers -t cimg/node:19.0-browsers .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
-docker push cimg/node:16.18
-docker push cimg/node:16.18.0
-docker push cimg/node:16.18-browsers
-docker push cimg/node:16.18.0-browsers
-docker push cimg/node:18.11
-docker push cimg/node:18.11.0
-docker tag cimg/node:18.11.0 cimg/node:current
+docker push cimg/node:19.0
+docker push cimg/node:19.0.0
+docker tag cimg/node:19.0.0 cimg/node:current
 docker push cimg/node:current
-docker push cimg/node:18.11-browsers
-docker push cimg/node:18.11.0-browsers
-docker tag cimg/node:18.11.0-browsers cimg/node:current-browsers
+docker push cimg/node:19.0-browsers
+docker push cimg/node:19.0.0-browsers
+docker tag cimg/node:19.0.0-browsers cimg/node:current-browsers
 docker push cimg/node:current-browsers


### PR DESCRIPTION
Publishes a new `cimg/node` image, `cimg/node:19.0.0` specifically, to Docker Hub for customer use. Customers using `cimg/node:current` will be updated as well, though we can manually disable that if needed.

Rollback options:

For the main image tag, `19.0.0`, there's not really anything to roll back. If needed, we could simply delete it. Customers would have manually switches to this tag in order to use it in the first place.

For the alias tag `current`, it's a matter of retargeting which image it points to. In this case, the rollback procedure would be to alias `current` back to `18.11.0` and push that up to Docker Hub, a 1 minute procedure.