### PR TITLE
fix: need to initialize submodule for access to functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,4 +77,5 @@ jobs:
           name: Run version update script
           command: |
             sudo chmod +x nodeFeed.sh
+            git submodule update --init --recursive
             ./nodeFeed.sh


### PR DESCRIPTION
previous PR prepped the commit for merge, but accidentally took out submodule initialization thinking it came with the checkout step. this adds it back in so the scheduled pipeline has access to necessary functions