### PR TITLE
feat: adds a notify step for new images updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ workflows:
             - slack/notify:
                 branch_pattern: release-v.+
                 event: pass
-                mentions: "@images"
+                mentions: "@jalexchen"
                 template: basic_success_1
           context: cimg-publishing
       - cimg/build-and-deploy:
@@ -43,6 +43,12 @@ workflows:
             branches:
               only:
                 - main
+          post-steps:
+            - slack/notify:
+                branch_pattern: main
+                event: fail
+                mentions: "@images"
+                template: basic_fail_1
           context: cimg-publishing
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   cimg: circleci/cimg@0.3.0
+  slack: circleci/slack@4.12.1
 
 parameters:
   cron:
@@ -28,6 +29,12 @@ workflows:
             branches:
               ignore:
                 - main
+          post-steps:
+            - slack/notify:
+                branch_pattern: release-v.+
+                event: pass
+                mentions: "@images"
+                template: basic_success_1
           context: cimg-publishing
       - cimg/build-and-deploy:
           name: "Deploy"


### PR DESCRIPTION
i can't use the word r-e-l-e-a-s-e, so here we are. adds notifications to the image-alerts channel so we are notified of any image updates that a user, or the bot, triggers

this should either inform a PR _should_ be made, or that a PR has been made, which should be implemented soon
