### PR TITLE
Add arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.0
+  cimg: circleci/cimg@0.3.1
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -12,19 +12,24 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 
 ENV NODE_VERSION %%VERSION_FULL%%
 
-RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
-	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+USER root
+
+RUN [[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="arm64" && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" && \
+	tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
 	rm node.tar.xz && \
-	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+	ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ENV PATH /home/circleci/.yarn/bin:$PATH
 
 ENV YARN_VERSION 1.22.19
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
-	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
+	ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
 
 # Install an alternative, but growing in popularity Node.js package manager
-RUN sudo npm install -g pnpm
+RUN npm install -g pnpm
+
+USER circleci

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=node
 parent=base
 variants=(browsers)
 namespace=cimg
+arm64=1

--- a/variants/browsers.Dockerfile.template
+++ b/variants/browsers.Dockerfile.template
@@ -10,30 +10,32 @@ FROM cimg/%%PARENT%%:%%PARENT_TAG%%
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 
+USER root
+
 # Install Selenium
 ENV SELENIUM_VER=3.141.59
 RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
-    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
     rm selenium-server-standalone-${SELENIUM_VER}.jar
 
-RUN sudo apt-get update && \
+RUN apt-get update && \
 
     # Install Java only if it's not already available
     # Java is installed for Selenium
     if ! command -v java > /dev/null; then \
         echo "Java not found in parent image, installing..." && \
-        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+        apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
     fi && \
 
     # Firefox deps
-    sudo apt-get install -y --no-install-recommends --no-upgrade \
+    apt-get install -y --no-install-recommends --no-upgrade \
 		libdbus-glib-1-2 \
 		libgtk-3-dev \
 		libxt6 \
 	&& \
     # Google Chrome deps
 	# Some of these packages should be pulled into their own section
-    sudo apt-get install -y --no-install-recommends --no-upgrade \
+    apt-get install -y --no-install-recommends --no-upgrade \
         fonts-liberation \
         libappindicator3-1 \
         libasound2 \
@@ -51,7 +53,7 @@ RUN sudo apt-get update && \
         xdg-utils \
 		xvfb \
 	&& \
-	sudo rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*
 
 # Below is setup to allow xvfb to start when the container starts up.
 # The label in particular allows this image to override what CircleCI does
@@ -60,9 +62,11 @@ LABEL com.circleci.preserve-entrypoint=true
 ENV DISPLAY=":99"
 #RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
 #	chmod +x /tmp/entrypoint && \
-#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
-RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
-	sudo chmod +x /docker-entrypoint.sh
+#	mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | tee /docker-entrypoint.sh && \
+	chmod +x /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/bin/sh"]
+
+USER circleci


### PR DESCRIPTION
# Description
Add arm64 support to the cimg/node image by using buildx to build multi arch images.

The majority of the work actually lives in the cimg-shared repo which is where the build commands are generated:

https://github.com/CircleCI-Public/cimg-shared/pull/83
https://github.com/CircleCI-Public/cimg-shared/pull/84

The main change to the Dockerfile here is an architecture check and switch to the `USER` directive. `sudo` in buildx builds generally causes errors when running Docker on linux.

See also changes to cimg-orb:

https://github.com/CircleCI-Public/cimg-orb/pull/51

Note: The browsers variant does not build for arm64, only amd64, due to a limitation with selenium server. We will address this in the future, once arm64 support is rolled out to the majority of images

Test build with buildx: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-node/1419/workflows/daea85da-b14a-479b-adc9-d9c358135e16/jobs/1486

# Reasons
To build multi architecture images and allow cimg/node to run on arm64 natively

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
