### PR TITLE
Publish v20.6.1. [release]

### DIFF
--- a/20.6/Dockerfile
+++ b/20.6/Dockerfile
@@ -10,7 +10,7 @@ FROM cimg/base:2023.07
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV NODE_VERSION 20.6.0
+ENV NODE_VERSION 20.6.1
 
 RUN [[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="arm64" && \
  	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" && \

--- a/20.6/browsers/Dockerfile
+++ b/20.6/browsers/Dockerfile
@@ -6,7 +6,7 @@
 # the browsers variant. The normal version is based on the node variant of that
 # image. As this IS a Node image, there isn't a node variant.
 
-FROM cimg/node:20.6.0
+FROM cimg/node:20.6.1
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/ALIASES
+++ b/ALIASES
@@ -1,2 +1,2 @@
 lts=18.17.1
-current=20.6.0
+current=20.6.1

--- a/GEN-CHECK
+++ b/GEN-CHECK
@@ -1,1 +1,1 @@
-GEN_CHECK=(20.6.0=current)
+GEN_CHECK=(20.6.1=current)

--- a/build-images.sh
+++ b/build-images.sh
@@ -4,5 +4,5 @@ set -eo pipefail
 
 docker context create cimg
 docker buildx create --use cimg
-docker buildx build --platform=linux/amd64,linux/arm64 --file 20.6/Dockerfile -t cimg/node:20.6.0 -t cimg/node:20.6 --push .
-docker buildx build --platform=linux/amd64 --file 20.6/browsers/Dockerfile -t cimg/node:20.6.0-browsers -t cimg/node:20.6-browsers --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 20.6/Dockerfile -t cimg/node:20.6.1 -t cimg/node:20.6 --push .
+docker buildx build --platform=linux/amd64 --file 20.6/browsers/Dockerfile -t cimg/node:20.6.1-browsers -t cimg/node:20.6-browsers --push .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 set -eo pipefail
-docker buildx imagetools create -t cimg/node:current cimg/node:20.6.0
-docker buildx imagetools create -t cimg/node:current-browsers cimg/node:20.6.0-browsers
+docker buildx imagetools create -t cimg/node:current cimg/node:20.6.1
+docker buildx imagetools create -t cimg/node:current-browsers cimg/node:20.6.1-browsers


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
Manual release of 20.6.1
