### PR TITLE
add push alias job for releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,14 @@ workflows:
                 event: fail
                 mentions: "@images"
                 template: basic_fail_1
+      - push-alias-tags:
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - cimg/build-and-deploy
+          context: cimg-publishing
 
 jobs:
   check-feed:
@@ -84,3 +92,19 @@ jobs:
             sudo chmod +x nodeFeed.sh
             git submodule update --init --recursive
             ./nodeFeed.sh
+
+  push-alias-tags:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - run:
+          name: "Log in to Docker"
+          command: |
+            echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USER" --password-stdin
+      - run:
+          name: "Push aliased tags if release"
+          command: |
+            if git log -1 --pretty=%s | grep "\[release\]"; then
+              git diff --quiet HEAD~1 ALIASES || ./push-images.sh
+            fi


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
enable alias tagging again on releases
 
# Reasons
customers noticed alias tags were not being pinned to lts and current releases

Please check through the following before opening your PR. Thank you!

- [N/A] I have made changes to the `Dockerfile.template` file only
- [N/A] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
