### PR TITLE
Update `yarn` to `1.22.22`

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,7 +20,7 @@ RUN [[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="arm64" && \
 
 ENV PATH /home/circleci/.yarn/bin:$PATH
 
-ENV YARN_VERSION 1.22.19
+ENV YARN_VERSION 1.22.22
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.

Updates `yarn` from `1.22.19` to `1.22.22`

# Reasons
Please provide reasoning for these changes and how this PR achieves them.

If applicable, include a link to the related GitHub issue that this PR will close.

Patch version update to pick up fixes for https://github.com/yarnpkg/yarn/issues/9005

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
