### PR TITLE
Replace current node (21) with new release (22)

### DIFF
--- a/nodeFeed.sh
+++ b/nodeFeed.sh
@@ -11,7 +11,7 @@ fi
 buildParameter () {
   local newVersionString=$1
   case $newVersionString in
-    21.*)
+    22.*)
       export builtParam="=current"
       ;;
     20.*)


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Replace Node 21 with Node 22 as the current release.

# Reasons
To support the proper release of the new cimg/node images based on Node 22 while keeping support for the LTS 20.x releases.
