### PR TITLE
chore: set 23.x as current and 22.x as lts

### DIFF
--- a/nodeFeed.sh
+++ b/nodeFeed.sh
@@ -11,10 +11,10 @@ fi
 buildParameter () {
   local newVersionString=$1
   case $newVersionString in
-    22.*)
+    23.*)
       export builtParam="=current"
       ;;
-    20.*)
+    22.*)
       export builtParam="=lts"
       ;;
     *)


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Update the build params for the `current` and `lts` release tag mechanism.

# Reasons
Closes issue #432

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
