### PR TITLE
refactor: remove unused xvfb code from browsers.Dockerfile.template

### DIFF
--- a/variants/browsers.Dockerfile.template
+++ b/variants/browsers.Dockerfile.template
@@ -58,9 +58,6 @@ RUN sudo apt-get update && \
 # when booting the image.
 LABEL com.circleci.preserve-entrypoint=true
 ENV DISPLAY=":99"
-#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
-#	chmod +x /tmp/entrypoint && \
-#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
 RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
 	sudo chmod +x /docker-entrypoint.sh
 


### PR DESCRIPTION
# Description

Remove redundant and commented-out code related to `Xvfb` from [variants/browsers.Dockerfile.template](https://github.com/CircleCI-Public/cimg-node/blob/main/variants/browsers.Dockerfile.template)

```Dockerfile
#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
#	chmod +x /tmp/entrypoint && \
#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
```

# Reasons

The code lines in the Dockerfile are an unused alternative to the following `RUN` command.

They were put there 5 years ago by PR https://github.com/CircleCI-Public/cimg-node/pull/111 and appear to be left-overs from testing. Leaving commented-out code in production is generally not good practice and in this case is just confusing.

# Checklist

Please check through the following before opening your PR. Thank you!

- [X] I have made changes to the `browsers.Dockerfile.template` file only
- [X] I have not made any manual changes to automatically generated files
- [X] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)