### PR TITLE
chore: remove deprecated blank lines from browsers.Dockerfile.template

### DIFF
--- a/variants/browsers.Dockerfile.template
+++ b/variants/browsers.Dockerfile.template
@@ -17,14 +17,12 @@ RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://seleniu
     rm selenium-server-standalone-${SELENIUM_VER}.jar
 
 RUN sudo apt-get update && \
-
     # Install Java only if it's not already available
     # Java is installed for Selenium
     if ! command -v java > /dev/null; then \
         echo "Java not found in parent image, installing..." && \
         sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
     fi && \
-
     # Firefox deps
     sudo apt-get install -y --no-install-recommends --no-upgrade \
 		libdbus-glib-1-2 \


### PR DESCRIPTION
## Description

Remove deprecated continuation blank lines from [variants/browsers.Dockerfile.template](https://github.com/CircleCI-Public/cimg-node/blob/main/variants/browsers.Dockerfile.template)

## Reasons

Build Docker Images issues a warning in the `main-wf` / `Test` job:

>  - NoEmptyContinuation: Empty continuation line (line 54)

https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-node/2867/workflows/4179788b-b2d5-4119-83de-4991a5838555/jobs/3054

This refers to the Docker build check [NoEmptyContinuation](https://docs.docker.com/reference/build-checks/no-empty-continuation/) which says:

> Support for such empty lines is deprecated, and a future BuildKit release will remove support for this syntax entirely, causing builds to break. To avoid future errors, remove the empty lines, or add comments, since lines with comments aren't considered empty.

- closes https://github.com/CircleCI-Public/cimg-node/issues/484

## Checklist

Please check through the following before opening your PR. Thank you!

- [X] I have made changes to the `browsers.Dockerfile.template` file only
- [X] I have not made any manual changes to automatically generated files
- [X] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
