### PR TITLE
Update Current to v25 and LTS to v24

### DIFF
--- a/nodeFeed.sh
+++ b/nodeFeed.sh
@@ -11,10 +11,10 @@ fi
 buildParameter () {
   local newVersionString=$1
   case $newVersionString in
-    24.*)
+    25.*)
       export builtParam="=current"
       ;;
-    22.*)
+    24.*)
       export builtParam="=lts"
       ;;
     *)


### PR DESCRIPTION
# Description

Apply `current` tag to v25 releases, and `lts` tag to v24 releases

# Reasons

- v25 became Current on [2025-10-15](https://nodejs.org/en/blog/release/v25.0.0)
- v24 became Active LTS on [2025-10-28](https://nodejs.org/en/blog/release/v24.11.0)

https://nodejs.org/en/about/previous-releases


# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the ~`Dockerfile.template`~ `nodeFeed.sh` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
    - FYI this link doesn't work, should go to https://github.com/CircleCI-Public/cimg-node/blob/main/.github/CONTRIBUTING.md
- [ ] ~(Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)~
