### PR TITLE
fix: adding missing DISPLAY env var

### DIFF
--- a/variants/browsers.Dockerfile.template
+++ b/variants/browsers.Dockerfile.template
@@ -56,6 +56,8 @@ RUN sudo apt-get update && \
 # when booting the image.
 LABEL com.circleci.preserve-entrypoint=true
 
+ENV DISPLAY=":99"
+
 RUN printf '#!/bin/sh\n\n' | sudo tee /docker-entrypoint.sh; \
     printf 'DISPLAY_NUM=:99\n' | sudo tee -a /docker-entrypoint.sh; \
     printf 'SCREEN_RES="1280x1024x24"\n' | sudo tee -a /docker-entrypoint.sh; \


### PR DESCRIPTION
# Description
This PR introduces a default `ENV DISPLAY` variable to the `Dockerfile.template`.

The environment variable is set to a common default value, typically `:99`, which is conventionally used by virtual frame buffer servers like Xvfb.

# Reasons
Setting a default `DISPLAY` environment variable significantly improves the out-of-the-box usability of this image for users running GUI-dependent applications or tests (e.g., Selenium, Cypress, or any application relying on X11) in conjunction with a virtual display server.

* **Simplifies User Configuration:** By providing a default `DISPLAY` value that matches the typical Xvfb setup in CircleCI environments (`:99.0` or similar), users no longer need to explicitly set this environment variable in their `.circleci/config.yml` file.
* **Encourages Best Practice:** It guides users toward the standard method for running headful tasks in a headless Docker environment, reducing configuration effort and potential errors.

This change is achieved by adding a single `ENV` instruction to the `Dockerfile.template`.

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [X] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)