### PR TITLE
fix: add Mesa GL libraries to browsers image for WebGL support in Docker

### DIFF
--- a/variants/browsers.Dockerfile.template
+++ b/variants/browsers.Dockerfile.template
@@ -28,6 +28,9 @@ RUN sudo apt-get update && \
         libdbus-glib-1-2 \
         libgtk-3-dev \
         libxt6 \
+        # Mesa software rendering - required for WebGL in Docker (no GPU available)
+        libgl1-mesa-dri \
+        libegl-mesa0 \
         && \
     # Google Chrome deps
     # Some of these packages should be pulled into their own section


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Add `libgl1-mesa-dri` and `libegl-mesa0` to the browsers variant Dockerfile template.

# Reasons
Docker containers have no GPU, so Firefox relies on Mesa's software renderer (llvmpipe) to provide an OpenGL/EGL backend for WebGL. Without these libraries, `HTMLCanvasElement.getContext('webgl')` non-deterministically returns `null` depending on system load at the time Firefox initialises its GPU process — causing intermittent WebGL test failures for users running browser tests in Docker executors.

# Checklist

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)